### PR TITLE
fix json_ecode error for non-sequential permissions array

### DIFF
--- a/api/application/helpers/acl_helper.php
+++ b/api/application/helpers/acl_helper.php
@@ -146,7 +146,7 @@ class ACL {
         $roles = $this->userRoles($user);
         $permissions = array();
         foreach ($roles as $role) {
-            $permissions = array_unique(array_merge($permissions, $this->rolePermissions($role, $resource)));
+           $permissions = array_values(array_unique(array_merge($permissions, $this->rolePermissions($role, $resource)))); 
         }
         return $permissions;
     }


### PR DESCRIPTION
Needed to wrap:
``
$permissions = array_unique(array_merge($permissions, $this->rolePermissions($role, $resource)));
``

In an `array_values()` like so:
``
$permissions = array_values(array_unique(array_merge($permissions, $this->rolePermissions($role, $resource))));
``

If we have the following roles ``aa`` and ``bb`` for resources ``xx`` and `yy`` like so:

Key | Value
------------ | -------------
resource_role_permissions::aa::xx | "create","read","update","delete"
resource_role_permissions::bb::xx | "read"
resource_role_permissions::aa::yy | "read"
resource_role_permissions::bb::yy | "create","read","update","delete"

In the case were the current use is a member of both `aa` and `bb` the permissions should be combined. 

With  `aa::xx` having more permissions than `bb:xx` and `aa` is before `bb` then `userPermissions()` returns an array of `[0] = "create"`, `[1] = "read"`, `[2] = "update"`, `[3] = "delete"` that is in sequential order. 

When `view/json.php` uses `echo json_encode($output);` since it is working with a *sequential* array, an *array* is returned `[ "0":"create", "1":"read", "2":"update", "3":"delete" ]`

With  `aa::yy` having fewer permissions than `bb:yy` and  `aa` is before `bb` then `userPermissions()` returns an array of `[0] = "create"`, `[1] = "read"`, `[2] = "update"`, `[6] = "delete"` that is not sequential order. (delete in element 6 not element 3).

When `view/json.php` uses `echo json_encode($output);` since it is working with a *non-sequential* array, an *object* is returned `{ "0":"create", "1":"read", "2":"update", "6":"delete" }`

Using `array_values()` converts the *non-sequential* array to a *sequential* array if necessary in `userPermissions`.


